### PR TITLE
36 distribution filenames

### DIFF
--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -12,8 +12,11 @@ from infra.apps.catalog.storage.distribution_storage import \
 
 def distribution_file_path(instance, _filename=None):
     directory = distribution_directory(instance)
-    extension = instance.file.name.split('/')[-1].rsplit('.', maxsplit=1)[-1]
-    final_name = f'{instance.file_name}-{instance.uploaded_at}.{extension}'
+    decomposed_name = instance.file_name.rsplit('.', maxsplit=1)
+    final_name = f'{decomposed_name[0]}-{instance.uploaded_at}'
+    if len(decomposed_name) > 1:
+        # filename includes extension
+        final_name += f'.{decomposed_name[-1]}'
     return os.path.join(directory, final_name)
 
 

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -50,7 +50,7 @@ class Distribution(models.Model):
 
     def file_name_with_date(self):
         path = Path(self.file.name)
-        return path.stem
+        return path.name
 
     def file_path(self):
         path = Path(self.file.name)

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -12,8 +12,8 @@ from infra.apps.catalog.storage.distribution_storage import \
 
 def distribution_file_path(instance, _filename=None):
     directory = distribution_directory(instance)
-    name, extension = instance.file.name.split('/')[-1].rsplit('.', maxsplit=1)
-    final_name = f'{name}-{instance.uploaded_at}.{extension}'
+    extension = instance.file.name.split('/')[-1].rsplit('.', maxsplit=1)[-1]
+    final_name = f'{instance.file_name}-{instance.uploaded_at}.{extension}'
     return os.path.join(directory, final_name)
 
 

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -48,3 +48,7 @@ class Distribution(models.Model):
     def file_name_with_date(self):
         path = Path(self.file.name)
         return path.stem
+
+    def file_path(self):
+        path = Path(self.file.name)
+        return path.with_name(self.file_name)

--- a/infra/apps/catalog/templates/distributions/node_distributions.html
+++ b/infra/apps/catalog/templates/distributions/node_distributions.html
@@ -10,7 +10,7 @@
     <br/>
 {% for id, distributions in object_list.items %}
     <p>
-        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}catalog/{{ distribution.node }}/dataset/{{ distribution.dataset_identifier }}/distribution/{{ distribution.identifier }}/download/{{ distribution.file_name }}" download="{{ distribution.file_name }}">{% if forloop.first %}{{ distribution.file_name }}{% else %}{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
+        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}{% if forloop.first %}{{ distribution.file_path }}" download="{{ distribution.file_name }}">{{ distribution.file_name }}{% else %}{{ distribution.file.name }}" download="{{ distribution.file_name_with_date }}">{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
     </p>
 {% endfor %}
 {% endblock %}

--- a/infra/apps/catalog/templates/distributions/node_distributions.html
+++ b/infra/apps/catalog/templates/distributions/node_distributions.html
@@ -10,7 +10,7 @@
     <br/>
 {% for id, distributions in object_list.items %}
     <p>
-        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}{{ distribution.file.name }}">{% if forloop.first %}{{ distribution.file_name }}{% else %}{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
+        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}{{ distribution.file.name }}" download="{{ distribution.file_name }}">{% if forloop.first %}{{ distribution.file_name }}{% else %}{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
     </p>
 {% endfor %}
 {% endblock %}

--- a/infra/apps/catalog/templates/distributions/node_distributions.html
+++ b/infra/apps/catalog/templates/distributions/node_distributions.html
@@ -10,7 +10,7 @@
     <br/>
 {% for id, distributions in object_list.items %}
     <p>
-        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}{{ distribution.file.name }}" download="{{ distribution.file_name }}">{% if forloop.first %}{{ distribution.file_name }}{% else %}{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
+        <a href="{% url 'catalog:distribution_uploads' node_id=node.id identifier=distributions.0.identifier%}">Distribución: {{ id }}</a> ({% for distribution in distributions %}<a href="{% get_media_prefix  %}catalog/{{ distribution.node }}/dataset/{{ distribution.dataset_identifier }}/distribution/{{ distribution.identifier }}/download/{{ distribution.file_name }}" download="{{ distribution.file_name }}">{% if forloop.first %}{{ distribution.file_name }}{% else %}{{ distribution.file_name_with_date }}{% endif %}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
     </p>
 {% endfor %}
 {% endblock %}

--- a/infra/apps/catalog/templates/distributions/node_distributions.html
+++ b/infra/apps/catalog/templates/distributions/node_distributions.html
@@ -15,10 +15,10 @@
             Distribución: {{ id }}
         </a>
         ({% for distribution in distributions %}
-            <a href="{% get_media_prefix  %}{% if forloop.first %}
-                {{ distribution.file_path }}" download="{{ distribution.file_name }}">{{ distribution.file_name }}
-            {% else %}
-                {{ distribution.file.name }}" download="{{ distribution.file_name_with_date }}">{{ distribution.file_name_with_date }}{% endif %}
+            <a href="{% get_media_prefix  %}{% if forloop.first %}{{ distribution.file_path }}"
+                 download="{{ distribution.file_name }}">{{ distribution.file_name }}
+            {% else %}{{ distribution.file.name }}"
+                download="{{ distribution.file_name_with_date }}">{{ distribution.file_name_with_date }}{% endif %}
             </a>{% if not forloop.last %} | {% endif %}
         {% endfor %})
     </p>

--- a/infra/apps/catalog/templates/distributions/uploads.html
+++ b/infra/apps/catalog/templates/distributions/uploads.html
@@ -10,13 +10,13 @@
 
 <h3>Archivos actuales</h3>
 <div class="container">
-    <a class="catalogs" href="{% get_media_prefix  %}{{ object_list.0.file.name }}" download="{{ object_list.0.file_name }}">{{ object_list.0.file_name }}</a>
+    <a class="catalogs" href="{% get_media_prefix  %}{{ object_list.0.file_path }}" download="{{ object_list.0.file_name }}">{{ object_list.0.file_name }}</a>
 </div>
 
 <h3>Versiones anteriores</h3>
 <div class="container">
     {% for distribution in object_list %}
-        <a class="catalogs" href="{% get_media_prefix  %}{{ distribution.file.name }}" download="{{ distribution.file_name }}">{{ distribution.file_name }} ({{ distribution.uploaded_at }})</a>
+        <a class="catalogs" href="{% get_media_prefix  %}{{ distribution.file.name }}" download="{{ distribution.file_name_with_date }}">{{ distribution.file_name }} ({{ distribution.uploaded_at }})</a>
     {% endfor %}
 </div>
 

--- a/infra/apps/catalog/tests/models/distribution_tests.py
+++ b/infra/apps/catalog/tests/models/distribution_tests.py
@@ -88,7 +88,7 @@ def test_upload_distribution_filename_with_extension(catalog):
                                         identifier='125.1',
                                         file=File(distribution))
         dist_filename = Path(Distribution.objects.first().file.name).name
-    assert 'file_with_extension-2019-01-01.csv' == dist_filename
+    assert dist_filename == 'file_with_extension-2019-01-01.csv'
 
 
 def test_upload_distribution_filename_without_extension(catalog):
@@ -100,4 +100,4 @@ def test_upload_distribution_filename_without_extension(catalog):
                                         identifier='125.1',
                                         file=File(distribution))
         dist_filename = Path(Distribution.objects.first().file.name).name
-    assert 'file_without_extension-2019-01-01' == dist_filename
+    assert dist_filename == 'file_without_extension-2019-01-01'

--- a/infra/apps/catalog/tests/models/distribution_tests.py
+++ b/infra/apps/catalog/tests/models/distribution_tests.py
@@ -1,8 +1,10 @@
 import os
+from pathlib import Path
 
 import pytest
 from django.conf import settings
 from django.core.files import File
+from freezegun import freeze_time
 
 from infra.apps.catalog.exceptions.catalog_not_uploaded_error import CatalogNotUploadedError
 from infra.apps.catalog.models.distribution import Distribution
@@ -75,3 +77,27 @@ def test_file_saved_as_latest(catalog):
                                        '125.1',
                                        'download',
                                        distribution.file_name))
+
+
+def test_upload_distribution_filename_with_extension(catalog):
+    with freeze_time('2019-01-01'):
+        with open_catalog('test_data.csv') as distribution:
+            Distribution.objects.create(node=catalog.node,
+                                        dataset_identifier='125',
+                                        file_name='file_with_extension.csv',
+                                        identifier='125.1',
+                                        file=File(distribution))
+        dist_filename = Path(Distribution.objects.first().file.name).name
+    assert 'file_with_extension-2019-01-01.csv' == dist_filename
+
+
+def test_upload_distribution_filename_without_extension(catalog):
+    with freeze_time('2019-01-01'):
+        with open_catalog('test_data.csv') as distribution:
+            Distribution.objects.create(node=catalog.node,
+                                        dataset_identifier='125',
+                                        file_name='file_without_extension',
+                                        identifier='125.1',
+                                        file=File(distribution))
+        dist_filename = Path(Distribution.objects.first().file.name).name
+    assert 'file_without_extension-2019-01-01' == dist_filename

--- a/infra/apps/catalog/tests/views/list_distributions_tests.py
+++ b/infra/apps/catalog/tests/views/list_distributions_tests.py
@@ -27,5 +27,9 @@ def test_distribution_list_download_link(user, distribution, logged_client):
                                          kwargs={
                                              'node_id': distribution.node.id}
                                          ))
-    download_attribute = 'download="test_data.csv"'
-    assert download_attribute in response.content.decode('utf-8')
+    href = '/media/catalog/test_id/dataset/125/distribution/125.1' \
+           '/download/test_data.csv'
+    filename = 'test_data.csv'
+    download_anchor = f'<a href="{href}" download="{filename}">' \
+                      f'{filename}</a>'
+    assert download_anchor in response.content.decode('utf-8')

--- a/infra/apps/catalog/tests/views/list_distributions_tests.py
+++ b/infra/apps/catalog/tests/views/list_distributions_tests.py
@@ -17,3 +17,15 @@ def test_link_to_detail_page(user, distribution, logged_client):
         'identifier': distribution.identifier
     })
     assert detail_url in response.content.decode('utf-8')
+
+
+def test_distribution_list_download_link(user, distribution, logged_client):
+    node = distribution.node
+    node.admins.add(user)
+    node.save()
+    response = logged_client.get(reverse('catalog:node_distributions',
+                                         kwargs={
+                                             'node_id': distribution.node.id}
+                                         ))
+    download_attribute = 'download="test_data.csv"'
+    assert download_attribute in response.content.decode('utf-8')


### PR DESCRIPTION
Closes #36 

- Guarda los archivos de distribuciones con el filename provisto por el form
- Cambia los links de descarga en los templates para que usen el filename del modelo de distribución en lugar del nombre del archivo guardado 