### PR TITLE
Cambio permisos de archivos  644 -> 664

### DIFF
--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -144,3 +144,5 @@ EMAIL_BACKEND = 'des.backends.ConfiguredEmailBackend'
 DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='infra.datos.gob.ar@modernizacion.gob.ar')
 
 AUTH_USER_MODEL = 'users.User'
+
+FILE_UPLOAD_PERMISSIONS = 0o664

--- a/infra/apps/catalog/tests/models/catalog_tests.py
+++ b/infra/apps/catalog/tests/models/catalog_tests.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 import pytest
 from django.conf import settings
@@ -116,3 +117,9 @@ def test_validate_returns_error_message_if_catalog_is_not_valid(node):
 
     for error_message in error_messages:
         assert error_message in validation_result
+
+
+def test_upload_file_permissions(catalog):
+    # As per https://stackoverflow.com/questions/5337070/how-can-i-get-a-files-permission-mask
+    mask = oct(os.stat(catalog.file.path)[stat.ST_MODE])[-3:]
+    assert mask == '664'


### PR DESCRIPTION
Permite a usuarios del mismo grupo pisar archivos. En ambientes productivos, el grupo del usuario que corre la aplicación es uno común a todos los usuarios que utilizan el servidor web, todos ellos deberían poder manipular los archivos.

Closes #55 