### PR TITLE
Sincronización de catálogos con el fs

### DIFF
--- a/infra/apps/catalog/exceptions/catalog_sync_error.py
+++ b/infra/apps/catalog/exceptions/catalog_sync_error.py
@@ -1,0 +1,2 @@
+class CatalogSyncError(RuntimeError):
+    pass

--- a/infra/apps/catalog/helpers/temp_uploaded_file.py
+++ b/infra/apps/catalog/helpers/temp_uploaded_file.py
@@ -1,4 +1,5 @@
 import os
+
 from django.core.files.uploadedfile import TemporaryUploadedFile
 
 

--- a/infra/apps/catalog/models/catalog_upload.py
+++ b/infra/apps/catalog/models/catalog_upload.py
@@ -10,7 +10,6 @@ from infra.apps.catalog.validator.catalog_data_validator import CatalogDataValid
 from infra.apps.catalog.helpers.file_name_for_format import file_name_for_format
 from infra.apps.catalog.storage.catalog_storage import CustomCatalogStorage
 from infra.apps.catalog.constants import CATALOG_ROOT
-from infra.apps.catalog.models.node import Node
 
 
 def catalog_file_path(instance, _filename=None):
@@ -34,7 +33,7 @@ class CatalogUpload(models.Model):
         (FORMAT_XLSX, 'XLSX'),
     ]
 
-    node = models.ForeignKey(to=Node, on_delete=models.CASCADE, unique_for_date='uploaded_at')
+    node = models.ForeignKey(to='Node', on_delete=models.CASCADE, unique_for_date='uploaded_at')
     format = models.CharField(max_length=4, blank=False, null=False, choices=FORMAT_OPTIONS)
     uploaded_at = models.DateField(auto_now_add=True)
     file = models.FileField(upload_to=catalog_file_path,
@@ -63,13 +62,18 @@ class CatalogUpload(models.Model):
     @classmethod
     def create_from_url_or_file(cls, raw_data):
         data = CatalogDataValidator().get_and_validate_data(raw_data)
-        with transaction.atomic():
-            cls.objects.filter(node=data['node'], uploaded_at=timezone.now().date()).delete()
-            catalog = cls.objects.create(**data)
+        catalog = cls.update_or_create(data)
 
         if not data.get('file').closed:
             data.get('file').close()
 
+        return catalog
+
+    @classmethod
+    def update_or_create(cls, data):
+        with transaction.atomic():
+            cls.objects.filter(node=data['node'], uploaded_at=timezone.now().date()).delete()
+            catalog = cls.objects.create(**data)
         return catalog
 
     def get_datasets(self):

--- a/infra/apps/catalog/models/catalog_upload.py
+++ b/infra/apps/catalog/models/catalog_upload.py
@@ -62,7 +62,7 @@ class CatalogUpload(models.Model):
     @classmethod
     def create_from_url_or_file(cls, raw_data):
         data = CatalogDataValidator().get_and_validate_data(raw_data)
-        catalog = cls.update_or_create(data)
+        catalog = cls.upsert(data)
 
         if not data.get('file').closed:
             data.get('file').close()
@@ -70,7 +70,7 @@ class CatalogUpload(models.Model):
         return catalog
 
     @classmethod
-    def update_or_create(cls, data):
+    def upsert(cls, data):
         with transaction.atomic():
             cls.objects.filter(node=data['node'], uploaded_at=timezone.now().date()).delete()
             catalog = cls.objects.create(**data)

--- a/infra/apps/catalog/models/node.py
+++ b/infra/apps/catalog/models/node.py
@@ -3,7 +3,7 @@ from django.db import models
 
 from infra.apps.catalog.exceptions.catalog_not_uploaded_error import CatalogNotUploadedError
 from infra.apps.catalog.storage.paths import latest_json_catalog_path
-from infra.apps.catalog.tests.helpers.temp_uploaded_file import temp_uploaded_file
+from infra.apps.catalog.helpers.temp_uploaded_file import temp_uploaded_file
 from infra.apps.catalog.validator.catalog_data_validator import CatalogDataValidator
 
 

--- a/infra/apps/catalog/models/node.py
+++ b/infra/apps/catalog/models/node.py
@@ -31,4 +31,4 @@ class Node(models.Model):
             'format': 'json',
         })
 
-        return CatalogUpload.update_or_create(catalog_data)
+        return CatalogUpload.upsert(catalog_data)

--- a/infra/apps/catalog/models/node.py
+++ b/infra/apps/catalog/models/node.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 
 from infra.apps.catalog.exceptions.catalog_not_uploaded_error import CatalogNotUploadedError
+from infra.apps.catalog.models.catalog_upload import CatalogUpload
 from infra.apps.catalog.storage.paths import latest_json_catalog_path
 from infra.apps.catalog.helpers.temp_uploaded_file import temp_uploaded_file
 from infra.apps.catalog.validator.catalog_data_validator import CatalogDataValidator
@@ -30,4 +31,4 @@ class Node(models.Model):
             'format': 'json',
         })
 
-        return self.catalogupload_set.create(**catalog_data)
+        return CatalogUpload.update_or_create(catalog_data)

--- a/infra/apps/catalog/models/node.py
+++ b/infra/apps/catalog/models/node.py
@@ -2,6 +2,9 @@ from django.conf import settings
 from django.db import models
 
 from infra.apps.catalog.exceptions.catalog_not_uploaded_error import CatalogNotUploadedError
+from infra.apps.catalog.storage.paths import latest_json_catalog_path
+from infra.apps.catalog.tests.helpers.temp_uploaded_file import temp_uploaded_file
+from infra.apps.catalog.validator.catalog_data_validator import CatalogDataValidator
 
 
 class Node(models.Model):
@@ -17,3 +20,14 @@ class Node(models.Model):
             raise CatalogNotUploadedError
 
         return catalog
+
+    def sync(self):
+        path = latest_json_catalog_path(self.identifier)
+
+        catalog_data = CatalogDataValidator().get_and_validate_data({
+            'file': temp_uploaded_file(open(path, 'rb')),
+            'node': self,
+            'format': 'json',
+        })
+
+        return self.catalogupload_set.create(**catalog_data)

--- a/infra/apps/catalog/storage/catalog_storage.py
+++ b/infra/apps/catalog/storage/catalog_storage.py
@@ -1,13 +1,10 @@
-import os
-
-from infra.apps.catalog.constants import CATALOG_ROOT
 from infra.apps.catalog.helpers.file_name_for_format import file_name_for_format
 from infra.apps.catalog.storage.infra_storage import InfraStorage
+from infra.apps.catalog.storage.paths import catalog_path
 
 
 class CustomCatalogStorage(InfraStorage):
     def latest_file_path(self, instance):
         name = file_name_for_format(instance)
-        return os.path.join(CATALOG_ROOT,
-                            instance.node.identifier,
+        return catalog_path(instance.node.identifier,
                             f'{name}.{instance.format}')

--- a/infra/apps/catalog/storage/paths.py
+++ b/infra/apps/catalog/storage/paths.py
@@ -1,0 +1,16 @@
+import os
+
+from django.conf import settings
+
+from infra.apps.catalog.constants import CATALOG_ROOT
+
+
+def catalog_path(identifier, file_name):
+    return os.path.join(CATALOG_ROOT,
+                        identifier,
+                        file_name)
+
+
+def latest_json_catalog_path(node_id):
+    return os.path.join(settings.MEDIA_ROOT,
+                        catalog_path(node_id, 'data.json'))

--- a/infra/apps/catalog/sync.py
+++ b/infra/apps/catalog/sync.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 
+from infra.apps.catalog.exceptions.catalog_sync_error import CatalogSyncError
 from infra.apps.catalog.models import Node
 
 
@@ -7,13 +8,11 @@ def sync_catalog(node_id):
     try:
         node = Node.objects.get(pk=node_id)
     except Node.DoesNotExist:
-        return ["Catálogo consultado no existe"]
+        raise CatalogSyncError("Catálogo consultado no existe")
 
     try:
         node.sync()
     except ValidationError as e:
-        return [f"Error de lectura del catálogo: {str(e)}"]
+        raise CatalogSyncError(f"Error de lectura del catálogo: {str(e)}")
     except FileNotFoundError:
-        return ["No se encontró un catálogo en el file system para este nodo"]
-
-    return []
+        raise CatalogSyncError("No se encontró un catálogo en el file system para este nodo")

--- a/infra/apps/catalog/sync.py
+++ b/infra/apps/catalog/sync.py
@@ -1,0 +1,19 @@
+from django.core.exceptions import ValidationError
+
+from infra.apps.catalog.models import Node
+
+
+def sync_catalog(node_id):
+    try:
+        node = Node.objects.get(pk=node_id)
+    except Node.DoesNotExist:
+        return ["Catálogo consultado no existe"]
+
+    try:
+        node.sync()
+    except ValidationError as e:
+        return [f"Error de lectura del catálogo: {str(e)}"]
+    except FileNotFoundError:
+        return ["No se encontró un catálogo en el file system para este nodo"]
+
+    return []

--- a/infra/apps/catalog/templates/nodes/uploads.html
+++ b/infra/apps/catalog/templates/nodes/uploads.html
@@ -28,8 +28,14 @@
         </div>
         <br>
         <div class="row">
-            <div class="col-sm-8 col-sm-offset-2">
+            <div class="inline col-sm-8 col-sm-offset-2">
                 <a class="btn btn-primary" href="{% url 'catalog:add_catalog' node_id=node_id %}">Subir nuevo catálogo</a>
+                {% if user.is_superuser %}
+                    <form class='form-inline' action="{% url 'catalog:sync_catalog' node_id=node_id %}" method="post">
+                    {% csrf_token %}
+                    <input type="submit" value="SYNC" class="btn btn-primary"/>
+                    </form>
+                {% endif %}
             </div>
         </div>
 

--- a/infra/apps/catalog/tests/conftest.py
+++ b/infra/apps/catalog/tests/conftest.py
@@ -37,8 +37,12 @@ def mock_request():
     return requests_mock.mock()
 
 
+def _node_id():
+    return 'test_id'
+
+
 def _node():
-    return Node.objects.get_or_create(identifier='test_id')[0]
+    return Node.objects.get_or_create(identifier=_node_id())[0]
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -103,3 +107,22 @@ def _catalog():
         model.save()
 
     return model
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access(db):
+    # pylint: disable=W0613,C0103
+    pass
+
+
+@pytest.fixture
+def catalog_dest():
+    dest_dir = os.path.join(settings.MEDIA_ROOT,
+                            'catalog',
+                            _node_id())
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, 'data.json')
+
+    yield dest
+    if os.path.exists(dest):
+        os.remove(dest)

--- a/infra/apps/catalog/tests/helpers/open_catalog.py
+++ b/infra/apps/catalog/tests/helpers/open_catalog.py
@@ -3,5 +3,9 @@ import os
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), "..", "samples")
 
 
+def catalog_path(file_name):
+    return os.path.join(SAMPLES_DIR, file_name)
+
+
 def open_catalog(file_name):
-    return open(os.path.join(SAMPLES_DIR, file_name), 'rb')
+    return open(catalog_path(file_name), 'rb')

--- a/infra/apps/catalog/tests/models/catalog_tests.py
+++ b/infra/apps/catalog/tests/models/catalog_tests.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from infra.apps.catalog.models import CatalogUpload
 from infra.apps.catalog.tests.helpers.open_catalog import open_catalog
-from infra.apps.catalog.tests.helpers.temp_uploaded_file import temp_uploaded_file
+from infra.apps.catalog.helpers.temp_uploaded_file import temp_uploaded_file
 
 pytestmark = pytest.mark.django_db
 

--- a/infra/apps/catalog/tests/sync_tests.py
+++ b/infra/apps/catalog/tests/sync_tests.py
@@ -1,0 +1,23 @@
+from shutil import copy2
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from infra.apps.catalog.tests.helpers.open_catalog import catalog_path
+
+
+def test_sync_valid_catalog(node, catalog_dest):
+    copy2(catalog_path('data.json'), catalog_dest)
+    node.sync()
+    assert node.catalogupload_set.count() == 1
+
+
+def test_sync_catalog_nothing_uploaded(node):
+    with pytest.raises(FileNotFoundError):
+        node.sync()
+
+
+def test_sync_invalid_catalog(node, catalog_dest):
+    copy2(catalog_path('catalogo-justicia.xlsx'), catalog_dest)
+    with pytest.raises(ValidationError):
+        node.sync()

--- a/infra/apps/catalog/tests/validator/validator_tests.py
+++ b/infra/apps/catalog/tests/validator/validator_tests.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from requests import RequestException
 
 from infra.apps.catalog.tests.helpers.open_catalog import open_catalog
-from infra.apps.catalog.tests.helpers.temp_uploaded_file import temp_uploaded_file
+from infra.apps.catalog.helpers.temp_uploaded_file import temp_uploaded_file
 from infra.apps.catalog.validator.catalog_data_validator import CatalogDataValidator
 
 pytestmark = pytest.mark.django_db

--- a/infra/apps/catalog/tests/views/sync_catalog_tests.py
+++ b/infra/apps/catalog/tests/views/sync_catalog_tests.py
@@ -1,0 +1,36 @@
+from shutil import copy2
+
+from django.urls import reverse
+
+from infra.apps.catalog.tests.helpers.open_catalog import catalog_path
+
+
+def test_sync_catalog_not_superuser(logged_client, node):
+
+    response = logged_client.post(reverse('catalog:sync_catalog', kwargs={'node_id': node.id}))
+
+    assert response.status_code == 403
+
+
+def test_sync_catalog_invalid_id(admin_client):
+
+    response = admin_client.post(reverse('catalog:sync_catalog', kwargs={'node_id': '1'}))
+
+    assert response.status_code == 400
+
+
+def test_invalid_catalog_in_file_system(admin_client, node, catalog_dest):
+    copy2(catalog_path('catalogo-justicia.xlsx'), catalog_dest)
+    response = admin_client.post(reverse('catalog:sync_catalog', kwargs={'node_id': node.id}))
+    assert response.status_code == 400
+
+
+def test_sync_catalog_not_found(admin_client, node):
+    response = admin_client.post(reverse('catalog:sync_catalog', kwargs={'node_id': node.id}))
+    assert response.status_code == 400
+
+
+def test_sync_valid_catalog(admin_client, node, catalog_dest):
+    copy2(catalog_path('data.json'), catalog_dest)
+    admin_client.post(reverse('catalog:sync_catalog', kwargs={'node_id': node.id}))
+    assert node.catalogupload_set.count() == 1

--- a/infra/apps/catalog/urls.py
+++ b/infra/apps/catalog/urls.py
@@ -28,5 +28,8 @@ urlpatterns = [
          name='distribution_uploads'),
     path('<int:node_id>/distributions/<str:identifier>/new/',
          catalog_views.AddDistributionVersionView.as_view(),
-         name='add_distribution_version')
+         name='add_distribution_version'),
+    path('<int:node_id>/sync/',
+         catalog_views.SyncCatalog.as_view(),
+         name='sync_catalog'),
 ]


### PR DESCRIPTION
Closes #54 

Agrega boton de SYNC en la vista de nodos, sólo para el super usuario. Al clickear el botón, se busca el catálogo con nombre `data.json` en el file system, en el path `MEDIA_ROOT/catalog/<node_identifier/`, y se crea un nuevo `CatalogUpload` a partir de sus datos.