### PR TITLE
Botones duplicados para distribuciones del mismo día

### DIFF
--- a/infra/apps/catalog/context_managers.py
+++ b/infra/apps/catalog/context_managers.py
@@ -1,0 +1,19 @@
+import os
+from contextlib import contextmanager
+
+from django.conf import settings
+
+
+@contextmanager
+def distribution_file_handler(same_day_version, new_file_name):
+    try:
+        file_path_without_date = os.path.join(settings.MEDIA_ROOT, same_day_version.file_path())
+        file_path_with_date = \
+            os.path.join(settings.MEDIA_ROOT, same_day_version.file_path(with_date=True))
+        yield
+        if new_file_name != same_day_version.file_name:
+            os.remove(file_path_without_date)
+            os.remove(file_path_with_date)
+    except AttributeError:
+        # No hay versión anterior, por lo que 'same_day_version' es None y 'file_path()' tira error
+        yield

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-from django.conf import settings
 from django.core.files import File
 from django.db import models
 from django.utils import timezone

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -52,6 +52,6 @@ class Distribution(models.Model):
         path = Path(self.file.name)
         return path.name
 
-    def file_path(self):
+    def file_path(self, with_date=False):
         path = Path(self.file.name)
-        return path.with_name(self.file_name)
+        return path.with_name(self.file_name_with_date() if with_date else self.file_name)

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -41,11 +41,6 @@ class Distribution(models.Model):
     @classmethod
     def update_or_create(cls, raw_data):
         file = raw_data.get('file') or File(temp_file_from_url(raw_data['url']))
-        version = cls.get_version_from_same_day(raw_data['node'],
-                                                raw_data['distribution_identifier'])
-        if version:
-            os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path()))
-            os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path(with_date=True)))
         distribution, _ = cls.objects.update_or_create(
             node=raw_data['node'],
             identifier=raw_data['distribution_identifier'],

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -22,14 +22,6 @@ def distribution_file_path(instance, _filename=None):
     return os.path.join(directory, final_name)
 
 
-def get_version_from_same_day(node, dataset_identifier):
-    versions_from_today = Distribution.objects.filter(
-        identifier=dataset_identifier,
-        node=node,
-        uploaded_at=timezone.now().date())
-    return versions_from_today[0] if versions_from_today else None
-
-
 class Distribution(models.Model):
     node = models.ForeignKey(to=Node, on_delete=models.CASCADE, unique_for_date='uploaded_at')
     uploaded_at = models.DateField(auto_now_add=True)
@@ -49,7 +41,8 @@ class Distribution(models.Model):
     @classmethod
     def create_from_url(cls, raw_data):
         file = File(temp_file_from_url(raw_data['url']))
-        version = get_version_from_same_day(raw_data['node'], raw_data['distribution_identifier'])
+        version = cls.get_version_from_same_day(raw_data['node'],
+                                                raw_data['distribution_identifier'])
         if version:
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path()))
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path(with_date=True)))
@@ -62,6 +55,14 @@ class Distribution(models.Model):
                       'file_name': raw_data['file_name']}
         )
         return distribution
+
+    @classmethod
+    def get_version_from_same_day(cls, node, distribution_identifier):
+        versions_from_today = Distribution.objects.filter(
+            identifier=distribution_identifier,
+            node=node,
+            uploaded_at=timezone.now().date())
+        return versions_from_today[0] if versions_from_today else None
 
     def __str__(self):
         return self.identifier

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -53,7 +53,7 @@ class Distribution(models.Model):
         if version:
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path()))
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path(with_date=True)))
-        return cls.objects.update_or_create(
+        distribution, _ = cls.objects.update_or_create(
             node=raw_data['node'],
             identifier=raw_data['distribution_identifier'],
             uploaded_at=timezone.now().date(),
@@ -61,6 +61,7 @@ class Distribution(models.Model):
                       'file': file,
                       'file_name': raw_data['file_name']}
         )
+        return distribution
 
     def __str__(self):
         return self.identifier

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -42,7 +42,7 @@ class Distribution(models.Model):
     def update_or_create(cls, raw_data):
         file = raw_data.get('file') or File(temp_file_from_url(raw_data['url']))
         same_day_version = cls.get_version_from_same_day(raw_data['node'],
-                                                raw_data['distribution_identifier'])
+                                                         raw_data['distribution_identifier'])
         with distribution_file_handler(same_day_version, raw_data['file_name']):
             distribution, _ = cls.objects.update_or_create(
                 node=raw_data['node'],

--- a/infra/apps/catalog/models/distribution.py
+++ b/infra/apps/catalog/models/distribution.py
@@ -39,8 +39,8 @@ class Distribution(models.Model):
         self.file.storage.save_as_latest(self)
 
     @classmethod
-    def create_from_url(cls, raw_data):
-        file = File(temp_file_from_url(raw_data['url']))
+    def update_or_create(cls, raw_data):
+        file = raw_data.get('file') or File(temp_file_from_url(raw_data['url']))
         version = cls.get_version_from_same_day(raw_data['node'],
                                                 raw_data['distribution_identifier'])
         if version:

--- a/infra/apps/catalog/tests/models/distribution_tests.py
+++ b/infra/apps/catalog/tests/models/distribution_tests.py
@@ -44,7 +44,7 @@ def test_read_from_url(catalog, requests_mock):
                 'distribution_identifier': "125.1",
                 'node': catalog.node,
                 'url': url}
-    distribution = Distribution.create_from_url(raw_data)
+    distribution = Distribution.update_or_create(raw_data)
     assert distribution.file.read() == b'test_content'
 
 

--- a/infra/apps/catalog/tests/models/distribution_tests.py
+++ b/infra/apps/catalog/tests/models/distribution_tests.py
@@ -41,7 +41,7 @@ def test_read_from_url(catalog, requests_mock):
 
     raw_data = {'dataset_identifier': '125',
                 'file_name': 'data.csv',
-                'identifier': "125.1",
+                'distribution_identifier': "125.1",
                 'node': catalog.node,
                 'url': url}
     distribution = Distribution.create_from_url(raw_data)

--- a/infra/apps/catalog/tests/views/add_distribution_tests.py
+++ b/infra/apps/catalog/tests/views/add_distribution_tests.py
@@ -128,11 +128,11 @@ def test_generated_file_paths_for_distribution(admin_client, catalog):
 
         admin_client.post(_add_url(catalog.node), form_data)
     distribution = Distribution.objects.get()
-    assert str(distribution.file_path()) == \
-           'catalog/test_id/dataset/125/distribution/125.1/download/test_data.csv'
-    assert str(distribution.file_path(with_date=True)) == \
-           f'catalog/test_id/dataset/125/distribution/125.1/download/test_data-' \
-           f'{timezone.now().date()}.csv'
+    assert str(distribution.file_path()) == 'catalog/test_id/dataset/125/distribution/125.1/' \
+                                            'download/test_data.csv'
+    assert str(distribution.file_path(with_date=True)) == f'catalog/test_id/dataset/125/' \
+                                                          f'distribution/125.1/download/test_data' \
+                                                          f'-{timezone.now().date()}.csv'
 
 
 def _add_url(node):

--- a/infra/apps/catalog/tests/views/add_distribution_tests.py
+++ b/infra/apps/catalog/tests/views/add_distribution_tests.py
@@ -87,7 +87,7 @@ def test_create_from_file(admin_client, catalog):
     assert Distribution.objects.get().identifier == "125.1"
 
 
-def test_post_new_version_twice_generates_two_instances(client, catalog):
+def test_posting_new_version_twice_persists_only_one_instance(client, catalog):
     with open_catalog('test_data.csv') as sample:
         form_data = {'file': sample,
                      'dataset_identifier': "125",
@@ -98,7 +98,7 @@ def test_post_new_version_twice_generates_two_instances(client, catalog):
 
         sample.seek(0)
         client.post(_add_version_url(catalog.node, form_data['distribution_identifier']), form_data)
-    assert Distribution.objects.count() == 2
+    assert Distribution.objects.count() == 1
 
 
 def test_new_version_form_contains_previous_data(client, catalog):

--- a/infra/apps/catalog/views.py
+++ b/infra/apps/catalog/views.py
@@ -19,7 +19,6 @@ from infra.apps.catalog.exceptions.catalog_not_uploaded_error import \
 from infra.apps.catalog.forms import CatalogForm, DistributionForm
 from infra.apps.catalog.mixins import UserIsNodeAdminMixin
 from infra.apps.catalog.models import CatalogUpload, Node, Distribution
-from infra.apps.catalog.models.distribution import get_version_from_same_day
 from infra.apps.catalog.validator.url_or_file import URLOrFileValidator
 
 
@@ -105,7 +104,10 @@ class DistributionUpserter(TemplateView):
         return self.success_url(node)
 
     def create_from_file(self, node, form):
-        version = get_version_from_same_day(node, form.cleaned_data['distribution_identifier'])
+        version = Distribution.get_version_from_same_day(
+            node,
+            form.cleaned_data['distribution_identifier']
+        )
         if version:
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path()))
             os.remove(os.path.join(settings.MEDIA_ROOT, version.file_path(with_date=True)))


### PR DESCRIPTION
Modifico las funcionalidades de creación de distribuciones y versionado de las mismas para utilizar `update_or_create`, lo cual permite tener una única instancia de una distribución en vez de tener N rows en la base de datos, habiendo subido N veces una distribución *en un mismo día*.

El archivo en el filesystem perteneciente a una distribución siendo actualizada es eliminado.

Closes #56.