### PR TITLE
Show Permission error

### DIFF
--- a/infra/apps/catalog/views.py
+++ b/infra/apps/catalog/views.py
@@ -43,6 +43,9 @@ class AddCatalogView(LoginRequiredMixin, UserIsNodeAdminMixin, FormView):
         except ValidationError as e:
             messages.error(request, e)
             return self.form_invalid(form)
+        except PermissionError as e:
+            messages.error(request, e)
+            return self.form_invalid(form)
 
         validation_error_messages = catalog.validate()
         for error_message in validation_error_messages:


### PR DESCRIPTION
Se hace un catch  de la excepción PermissionError cuando se intenta modificar un archivo del cual no se tiene permisos. Esto es solo para mostrar al usuario que hay un problema y hay un archivo al cual se le cambiaron los permisos